### PR TITLE
Ensure battle log no longer covers overworld view

### DIFF
--- a/style.css
+++ b/style.css
@@ -138,16 +138,16 @@ footer {
 }
 
 .battle {
-  position: absolute;
-  inset: 0;
+  position: relative;
   display: grid;
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.92);
   color: #f8fafc;
   border-radius: 0.75rem;
-  padding: 1.5rem;
-  grid-template-rows: auto auto 1fr;
+  padding: 1.25rem;
+  grid-template-rows: auto auto auto;
   gap: 1rem;
   place-items: stretch;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.25);
 }
 
 .battle__panels {
@@ -213,6 +213,7 @@ footer {
   padding: 1rem;
   font-size: 0.95rem;
   overflow-y: auto;
+  max-height: 12rem;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- keep the battle interface within the page layout instead of overlaying the game canvas
- cap the battle log height so encounter text can scroll without hiding the world view

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68decea7fda083209f2b7119a2d2e9e2