### PR TITLE
Limit dialogue box height

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,6 +101,8 @@ canvas {
   border-radius: 0.75rem;
   font-size: 0.95rem;
   line-height: 1.4;
+  max-height: min(14rem, 35vh);
+  overflow-y: auto;
 }
 
 .instructions {


### PR DESCRIPTION
## Summary
- prevent the dialogue panel from overtaking the viewport by capping its height
- allow the dialogue panel to scroll vertically when text exceeds the cap

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e41c3e31548320a577782d3a173a2c