### PR TITLE
Add interactive NPC dialogue system

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,6 +105,58 @@ canvas {
   overflow-y: auto;
 }
 
+.dialogue--active {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(191, 219, 254, 0.8);
+  color: #f8fafc;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.35);
+}
+
+.dialogue__speaker {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.9);
+  margin: 0 0 0.35rem;
+}
+
+.dialogue__text {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.dialogue__choices {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.dialogue__choice {
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(191, 219, 254, 0.4);
+  color: inherit;
+  font: inherit;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.dialogue__choice:hover,
+.dialogue__choice:focus {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(191, 219, 254, 0.8);
+  outline: none;
+}
+
+.dialogue__prompt {
+  margin: 0.75rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
 .instructions {
   background: rgba(15, 23, 42, 0.05);
   border-radius: 0.75rem;


### PR DESCRIPTION
## Summary
- add dialogue state management with interaction key handling for NPC conversations
- define dialogue trees for each NPC with branching choices, rewards, and quest hooks
- render dialogue UI with styled prompts and ensure player control resumes after conversations

## Testing
- node --check game.js

------
https://chatgpt.com/codex/tasks/task_e_68e42c1f5120832091da24167328da91